### PR TITLE
Add persistent storage configuration for Quartz

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        url "https://jcenter.bintray.com/"
+    }
 }
 
 node {
@@ -46,6 +49,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
     implementation 'org.springdoc:springdoc-openapi-security:1.6.11'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    // Unfortunately not maintained. See https://github.com/michaelklishin/quartz-mongodb
+    implementation "com.novemberain:quartz-mongodb:2.2.0-rc2"
     compileOnly 'org.projectlombok:lombok:1.18.24'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/fi/asteriski/eventsignup/EventsignupApplication.java
+++ b/src/main/java/fi/asteriski/eventsignup/EventsignupApplication.java
@@ -11,9 +11,11 @@ import lombok.AllArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
+@EnableMongoAuditing
 @AllArgsConstructor
 public class EventsignupApplication implements CommandLineRunner {
 

--- a/src/main/java/fi/asteriski/eventsignup/config/AutowiringSpringBeanJobFactory.java
+++ b/src/main/java/fi/asteriski/eventsignup/config/AutowiringSpringBeanJobFactory.java
@@ -1,0 +1,28 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2022.
+Licenced under EUROPEAN UNION PUBLIC LICENCE v. 1.2.
+ */
+package fi.asteriski.eventsignup.config;
+
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+
+public final class AutowiringSpringBeanJobFactory extends SpringBeanJobFactory implements ApplicationContextAware {
+
+    private transient AutowireCapableBeanFactory beanFactory;
+
+    @Override
+    public void setApplicationContext(final ApplicationContext context) {
+        beanFactory = context.getAutowireCapableBeanFactory();
+    }
+
+    @Override
+    protected Object createJobInstance(final TriggerFiredBundle bundle) throws Exception {
+        final Object job = super.createJobInstance(bundle);
+        beanFactory.autowireBean(job);
+        return job;
+    }
+}

--- a/src/main/java/fi/asteriski/eventsignup/config/QuartzConfig.java
+++ b/src/main/java/fi/asteriski/eventsignup/config/QuartzConfig.java
@@ -1,0 +1,61 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2022.
+Licenced under EUROPEAN UNION PUBLIC LICENCE v. 1.2.
+ */
+package fi.asteriski.eventsignup.config;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.quartz.spi.JobFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.PropertiesFactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuartzConfig {
+
+    @NonNull
+    private ApplicationContext applicationContext;
+    @Value("${org.quartz.jobStore.mongoUri}")
+    private String mongoUrl;
+    @Value("${org.quartz.jobStore.dbName}")
+    private String mongoDatabaseName;
+
+    @Bean
+    public JobFactory jobFactory() {
+        AutowiringSpringBeanJobFactory jobFactory = new AutowiringSpringBeanJobFactory();
+        jobFactory.setApplicationContext(applicationContext);
+        return jobFactory;
+    }
+
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean() throws IOException {
+        SchedulerFactoryBean schedulerFactory = new SchedulerFactoryBean();
+        schedulerFactory.setQuartzProperties(quartzProperties());
+        schedulerFactory.setWaitForJobsToCompleteOnShutdown(true);
+        schedulerFactory.setAutoStartup(true);
+        schedulerFactory.setJobFactory(jobFactory());
+        return schedulerFactory;
+    }
+
+    public Properties quartzProperties() throws IOException {
+        PropertiesFactoryBean propertiesFactoryBean = new PropertiesFactoryBean();
+        propertiesFactoryBean.setLocation(new ClassPathResource("/quartz.properties"));
+        propertiesFactoryBean.afterPropertiesSet();
+
+        var properties = propertiesFactoryBean.getObject();
+        if (properties != null) {
+            properties.setProperty("org.quartz.jobStore.mongoUri", mongoUrl);
+            properties.setProperty("org.quartz.jobStore.dbName", mongoDatabaseName);
+        }
+        return properties;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,2 +1,6 @@
 root.path.bannerimg=/tmp/
 spring.mongodb.embedded.version=3.4.11
+
+# Quartz config
+org.quartz.jobStore.mongoUri=mongodb://localhost:27017
+org.quartz.jobStore.dbName=eventsignup

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -20,6 +20,10 @@ spring.mail.port=${SMTP_PORT}
 spring.mail.username=${SMTP_USERNAME}
 spring.mail.password=${SMTP_PASSWORD}
 
+# Quartz config
+org.quartz.jobStore.mongoUri=mongodb://${MONGO_HOST}:${MONGO_PORT}
+org.quartz.jobStore.dbName=${MONGO_DATABASE_NAME}
+
 # custom config keys
 default.email.sender.address=${DEFAULT_SENDER_EMAIL}
 default.days.to.archive.past.events=${DEFAULT_DAYS_TO_ARCHIVE_PAST_EVENTS}

--- a/src/main/resources/quartz.properties
+++ b/src/main/resources/quartz.properties
@@ -1,0 +1,7 @@
+org.quartz.jobStore.class=com.novemberain.quartz.mongodb.MongoDBJobStore
+org.quartz.jobStore.mongoUri=IsSetInQuartzConfigClass
+org.quartz.jobStore.dbName=IsSetInQuartzConfigClass
+org.quartz.jobStore.collectionPrefix=quartz
+org.quartz.threadPool.threadCount=5
+org.quartz.jobStore.isClustered=false
+org.quartz.scheduler.instanceId=AUTO


### PR DESCRIPTION
Add configuration for Quartz scheduler to use MongoDB as the persistent storage.