### PR TITLE
Fix typescript-types version number generation

### DIFF
--- a/.github/workflows/build-artifacts-on-tag-and-on-develop.yml
+++ b/.github/workflows/build-artifacts-on-tag-and-on-develop.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Generate new version number
         run: ./gradlew generateTypesVersionNumber
+        env:
+          GIT_TAG: ${{ github.ref_name }}
 
       - name: Push new version to npm registry
         run: ./gradlew publishTypesPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ tasks.register('generateTsTypes', NpxTask) {
 
 tasks.register('generateTypesVersionNumber', NpmTask) {
     def tag = System.getenv("GIT_TAG")
-    if (tag && tag =~ '[0-9]+.[0-9]+.[0-9]+') {
+    if (tag && tag =~ '^[0-9]+\\.[0-9]+\\.[0-9]+$') {
         args = ["version", tag.substring(1)]
     } else {
         args = ["version", new Date().format('yyyyMMdd') + "." + new Date().format('HHmm') + ".0"]


### PR DESCRIPTION
Now when running the pipeline on a version tag the typescript-types
package will also get the same number as the tag instead of version
number based on the current date.

Closes #29 