### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/fi/asteriski/eventsignup/service/event/ImageServiceImpl.java
+++ b/src/main/java/fi/asteriski/eventsignup/service/event/ImageServiceImpl.java
@@ -37,6 +37,9 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     public byte[] getBannerImage(String fileName) {
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new ImageNotFoundException("Invalid filename");
+        }
         File filePath = new File(String.format(FILE_PATH_TEMPLATE, rootPath, fileName));
         if (!filePath.canRead()) {
             log.info(String.format("%s Requested file %s doesn't exist and/or cannot be read.", LOG_PREFIX, fileName));


### PR DESCRIPTION
Fixes [https://github.com/asteriskiry/eventsignup_backend/security/code-scanning/1](https://github.com/asteriskiry/eventsignup_backend/security/code-scanning/1)

To fix the problem, we need to validate the `fileName` parameter to ensure it does not contain any path traversal sequences or invalid characters. This can be done by checking for the presence of "..", "/", or "\\" in the `fileName` and rejecting the input if any are found. Additionally, we should ensure that the resolved path is within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
